### PR TITLE
Remove shadowRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,44 @@ using them.
 The goal is to be able to add this to a page:
 
 ```html
-<share-link label="Share"><a href="https://test.com/path/to/page">Link to this page</a></share-link>
+<share-link>
+	<a href="https://test.com/path/to/page">Link to this page</a>
+</share-link>
 ```
 
 — and have it render a button that triggers the **Web Share API**'s `share()` method,
 when clicked (the Web Share API requires [transient activation][TACT]).
 
-If the browser doesn't support the Web Share API, we should get a couple of links to
+If necessary, the URL and/or the button's label can be overriden with attributes on the
+element, e.g. to use the label "Share this" instead of "Link to this page" from the
+embedded link, do this:
+
+```html
+<share-link label="Share this">
+	<a href="https://test.com/path/to/page">Link to this page</a>
+</share-link>
+```
+
+Similarly, using the `url` attribute would allow you to modify the link destination, e.g.
+for tracking purposes etc.:
+
+```html
+<share-link url="https://test.com/path/to/page/?from=web-share-api" label="Share this link">
+	<a href="https://test.com/path/to/page/?from=no-js-fallback">Link to this page</a>
+</share-link>
+```
+
+## Notes
+
+* The rendered button can be styled with the global styles as any other element.
+
+* If the browser doesn't support the Web Share API, we should get a couple of links to
 **Facebook**'s and *maybe* **X**'s public share URLs, along with a generic "Copy link"
 button.
 
-If the browser doesn't support custom elements, the link inside should be rendered. (This would
+* If the browser doesn't support custom elements, the content inside should be rendered. (This would
 have to be manually specified by your CMS - *please don't use JavaScript to do this!* - this
-is the "last resort" case where if all else fails, at least we have a link we can manually copy).
+is the "last resort" case where if all else fails, at least we can have a link for manually copying).
 
 
 [CE]: https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements

--- a/src/index.html
+++ b/src/index.html
@@ -18,18 +18,51 @@
 			margin-inline: auto;
 			padding-block: 3rem;
 		}
+
+		button {
+			padding: 0.8em 1.3em;
+			border: 2px solid;
+			border-radius: 0.8em;
+			background: transparent;
+			cursor: pointer;
+			font: inherit;
+		}
 	</style>
 </head>
 <body>
 
 <main>
+	<h2>Standard link for reference</h2>
 	<p>
-		<a href="https://greystate.dk">A standard link</a>
+		<a href="https://greystate.dk">A link to my website</a>
+	</p>
+
+	<h2><code>&lt;share-link&gt;</code> Samples</h2>
+	<p>
+		A basic <code>&lt;share-link&gt;</code> with a single link inside should adopt its
+		URL &amp; label from the embedded link:
+	</p>
+	<p>
+		<share-link>
+			<a href="https://greystate.dk?sæt=høst&amp;vest=nord">A link to my website</a>
+		</share-link>
 	</p>
 
 	<p>
-		<share-link label="Share this"><a href="https://greystate.dk?sæt=høst&amp;vest=nord">A link to my website</a></share-link>
+		Adding the <code>url</code> + <code>label</code> attributes enables using more
+		elaborate fallback content.
 	</p>
+
+	<div>
+		<share-link url="https://greystate.dk?sæt=høst&amp;vest=nord" label="Share this">
+			<p>
+				Here's a link to my website for copying:
+				<code>https://greystate.dk?sæt=høst&amp;vest=nord</code>
+			</p>
+		</share-link>
+	</div>
+
+
 </main>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,11 @@
 			cursor: pointer;
 			font: inherit;
 		}
+
+		.btn {
+			background: orange;
+			font-weight: bold;
+		}
 	</style>
 </head>
 <body>
@@ -54,7 +59,7 @@
 	</p>
 
 	<div>
-		<share-link url="https://greystate.dk?sæt=høst&amp;vest=nord" label="Share this">
+		<share-link class="btn" url="https://greystate.dk?sæt=høst&amp;vest=nord" label="Share this">
 			<p>
 				Here's a link to my website for copying:
 				<code>https://greystate.dk?sæt=høst&amp;vest=nord</code>

--- a/src/share-link.js
+++ b/src/share-link.js
@@ -4,16 +4,34 @@ class ShareLink extends HTMLElement {
 	constructor() {
 		super()
 
-		this.attachShadow({ mode: 'open' })
+		this.canShare = false
+		this.shareUrl = null
+		this.shareLabel = ''
 	}
 
 	connectedCallback() {
-		const canShare = this.canUseWebShare(this.shareUrl)
+		// Try to take URL + label from embedded link
+		if (this.childElementCount == 1 && this.firstElementChild.hasAttribute('href')) {
+			this.shareUrl = this.firstElementChild.getAttribute('href')
+			this.shareLabel = this.firstElementChild.textContent
+		}
 
-		if (canShare) {
-			this.shadowRoot.appendChild(this.createShareButton())
+		// Override URL, if specified
+		if (this.hasAttribute('url')) {
+			this.shareUrl = this.getAttribute('url')
+		}
+
+		// Override label, if specified
+		if (this.hasAttribute('label')) {
+			this.shareLabel = this.getAttribute('label')
+		}
+
+		this.canShare = this.shareUrl != null && this.canUseWebShare(this.shareUrl)
+
+		if (this.canShare) {
+			this.replaceChildren(this.createShareButton())
 		} else {
-			this.shadowRoot.appendChild(this.createFallbackLinks())
+			this.replaceChildren(this.createFallbackLinks())
 		}
 	}
 
@@ -63,10 +81,6 @@ class ShareLink extends HTMLElement {
 		link.textContent = label
 		return link
 	}
-
-	get embeddedLink() { return this.firstElementChild }
-	get shareLabel() { return this.getAttribute('label') }
-	get shareUrl() { return this.embeddedLink.getAttribute('href') }
 }
 
 customElements.define('share-link', ShareLink)

--- a/src/share-link.js
+++ b/src/share-link.js
@@ -44,6 +44,8 @@ class ShareLink extends HTMLElement {
 		shareButton.setAttribute('type', 'button')
 		let label = document.createElement('span')
 		label.textContent = this.shareLabel
+		shareButton.classList.add(...this.classList)
+		this.removeAttribute('class')
 		shareButton.appendChild(label)
 
 		shareButton.addEventListener('click', (event) => {

--- a/src/share-link.js
+++ b/src/share-link.js
@@ -9,8 +9,6 @@ class ShareLink extends HTMLElement {
 
 	connectedCallback() {
 		const canShare = this.canUseWebShare(this.shareUrl)
-		const bgColor = canShare ? 'lime' : 'red'
-		console.info(`URL to share: ${this.shareUrl} (ok: ${canShare})`)
 
 		if (canShare) {
 			this.shadowRoot.appendChild(this.createShareButton())


### PR DESCRIPTION
This removes the use of the `shadowRoot` because we do actually want to be able to style the generated Share button from the hosting page.